### PR TITLE
Update pt.yml

### DIFF
--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -13,7 +13,7 @@ pt:
 
   flash:
     alert:
-      needs_login: "Você precisa estar lgoado para continuar"
+      needs_login: "Você precisa estar logado para continuar"
     notice:
       signed_in: 'Login efetuado com sucesso!'
       signed_out: 'Logout efetuado com sucesso. Até logo!'


### PR DESCRIPTION
Correção gramatical da mensagem do "needs_login" de "Você precisa estar lgoado para continuar" para "Você precisa estar logado para continuar".
