### PR TITLE
Fix: Não estava salvando a descrição do quarto

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -65,6 +65,6 @@ class RoomsController < ApplicationController
   end
 
   def room_params
-    params.require(:room).permit(:title, :location, :descriptio, :picture)
+    params.require(:room).permit(:title, :location, :description, :picture)
   end
 end


### PR DESCRIPTION
Pequeno erro de digitação no atributo "description" não permitia salvar o mesmo.